### PR TITLE
Fixed: The header image does not found on GitHub profile page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](./docs/theuhooi_logo_avenir_alpha.png)
+![](https://github.com/uhooi/uhooi/blob/master/docs/theuhooi_logo_avenir_alpha.png)
 
 [![uhooi's github stats](https://github-readme-stats.vercel.app/api?username=uhooi&show_icons=true)](https://github.com/uhooi)
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=uhooi)](https://github.com/uhooi)


### PR DESCRIPTION
We can't use relative paths to get the image to display properly on your GitHub profile page.